### PR TITLE
Fixes to autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,17 +3,12 @@ SUBDIRS = src doc examples
 BUILT_SOURCES = version.h
 EXTRA_DIST = version.h
 
-if DOT_SVN
-version.h: .svn/entries
-	echo \#define PACKAGE_VERSION_SVN_REV \"SVN-r`svnversion`\" > version.h
-else
 if DOT_GIT
 version.h: .git/HEAD .git/index
 	echo \#define PACKAGE_VERSION_SVN_REV \"GIT-`git describe --dirty --always --tags`\" > version.h
 else
 version.h:
 	echo \#define PACKAGE_VERSION_SVN_REV \"unknown\" > version.h
-endif
 endif
 
 clean-local:

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,6 @@ AC_CONFIG_AUX_DIR(build)
 AC_CONFIG_SRCDIR(src/esekeyd.c)
 AM_CONFIG_HEADER(config.h)
 AM_INIT_AUTOMAKE
-AM_CONDITIONAL([DOT_SVN], [test -f .svn/entries])
 AM_CONDITIONAL([DOT_GIT], [test -f .git/index])
 
 if test "$CFLAGS"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([ESE Key Daemon], [1.2.7], [krzysztof@burghardt.pl], [esekeyd])
 AC_CONFIG_AUX_DIR(build)
 AC_CONFIG_SRCDIR(src/esekeyd.c)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE
 AM_CONDITIONAL([DOT_GIT], [test -f .git/index])
 
@@ -31,7 +31,7 @@ open read close getopt_long)
 
 dnl Use option --enable-gcc-debug to enable GCC debug code. 
 AC_ARG_ENABLE(gcc-debug,
-AC_HELP_STRING([--enable-gcc-debug],
+AS_HELP_STRING([--enable-gcc-debug],
         [enable GCC DEBUG code]),
         [enable_gcc_debug=yes],
         [enable_gcc_debug=no])


### PR DESCRIPTION
* Remove DOT_SVN macros as obsoleted and useless.
* Fixes autotools deprecation warnings (`AM_CONFIG_HEADER` -> `AC_CONFIG_HEADERS`, `AC_HELP_STRING` -> `AS_HELP_STRING`).